### PR TITLE
Implement attack board icon cycling

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
                 <!-- Attack Board -->
                 <div class="board-section">
                     <h2>Enemy Fleet</h2>
+                    <p class="board-tip">Tip: once a square is unlocked you can click again to change 💧 / 💥 / 💀 without re-entering a conjugation.</p>
                     <div class="board-wrapper">
                         <div id="attack-board" class="game-board">
                         <div class="board-header">

--- a/script.js
+++ b/script.js
@@ -462,13 +462,26 @@ function checkIfShipSunk(type){
 
 function handleAttackBoardClick(cell) {
     if (gameState.phase !== 'battle') return;
-    
-    // Set the state based on current attack state
-    cell.dataset.state = gameState.currentAttackState;
-    cell.className = `board-cell ${gameState.currentAttackState}`;
-    
-    // Show attack modal for conjugation
-    showAttackModal(cell);
+
+    if (cell.dataset.unlocked !== 'true') {
+        // Apply chosen state and require conjugation
+        cell.dataset.state = gameState.currentAttackState;
+        cell.className = `board-cell ${gameState.currentAttackState}`;
+        showAttackModal(cell);
+        return;
+    }
+
+    // Already unlocked: simply cycle through states
+    cycleAttackIcon(cell);
+}
+
+function cycleAttackIcon(cell) {
+    const order = ['water', 'hit', 'sunk'];
+    let idx = order.indexOf(cell.dataset.state || 'water');
+    idx = (idx + 1) % order.length;
+    cell.dataset.state = order[idx];
+    cell.classList.remove('water', 'hit', 'sunk');
+    cell.classList.add(order[idx]);
 }
 
 function showAttackModal(cell) {
@@ -487,17 +500,17 @@ function showAttackModal(cell) {
     
     // Setup conjugation check
     const checkBtn = document.getElementById('check-conjugation-btn');
-    checkBtn.onclick = () => checkConjugation(verb, pronoun);
+    checkBtn.onclick = () => checkConjugation(cell, verb, pronoun);
     
     // Allow Enter key to check
     document.getElementById('conjugation').onkeypress = (e) => {
         if (e.key === 'Enter') {
-            checkConjugation(verb, pronoun);
+            checkConjugation(cell, verb, pronoun);
         }
     };
 }
 
-function checkConjugation(verb, pronoun) {
+function checkConjugation(cell, verb, pronoun) {
     const userInput = document.getElementById('conjugation').value.toLowerCase().trim();
     const resultDiv = document.getElementById('conjugation-result');
     
@@ -506,6 +519,7 @@ function checkConjugation(verb, pronoun) {
         
         if (userInput === correctAnswer) {
             resultDiv.innerHTML = '<div class="success">✓ Correct! You can make this attack.</div>';
+            cell.dataset.unlocked = 'true';
             setTimeout(() => {
                 closeModals();
             }, 1500);

--- a/style.css
+++ b/style.css
@@ -279,6 +279,15 @@ main {
     font-size: 1.3rem;
 }
 
+.board-tip {
+    text-align: center;
+    font-size: 0.9rem;
+    font-style: italic;
+    color: #555;
+    margin-top: -0.5rem;
+    margin-bottom: 1rem;
+}
+
 .board-wrapper {
     margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- allow attack board cells to cycle through 💧/💥/💀 once unlocked
- track unlock after successful conjugation
- show tip explaining icon cycling on the attack board

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687758f677a483279202231c9d5ac3b0