### PR TITLE
Update own board click handling and hide enemy board during placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
             </div>
 
                 <!-- Attack Board -->
-                <div class="board-section">
+                <div class="board-section enemy-board">
                     <h2>Enemy Fleet</h2>
                     <p class="attack-tip">💡 Tip: Once unlocked, click squares to cycle through 💧 / 💥 / 💀</p>
                     <div class="board-wrapper">

--- a/style.css
+++ b/style.css
@@ -494,8 +494,8 @@ main {
 }
 
 .board-section {
-    background: linear-gradient(135deg, 
-        rgba(30, 60, 114, 0.9) 0%, 
+    background: linear-gradient(135deg,
+        rgba(30, 60, 114, 0.9) 0%,
         rgba(42, 82, 152, 0.9) 100%);
     padding: 2rem;
     border-radius: 16px;
@@ -504,6 +504,10 @@ main {
         inset 0 1px 0 rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(66, 165, 245, 0.3);
     backdrop-filter: blur(10px);
+}
+
+.board-section.enemy-board.hidden {
+    display: none;
 }
 
 .board-section h2 {


### PR DESCRIPTION
## Summary
- prevent auto-setting water state when creating own board
- toggle empty cells between water and empty
- show/hide enemy board depending on phase
- apply enemy board class in HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687767205fdc83279efaa3c6d3fc981c