### PR TITLE
Reduce board size by 10% and align boards

### DIFF
--- a/style.css
+++ b/style.css
@@ -561,6 +561,18 @@ main {
     margin-bottom: 2rem;
 }
 
+/* Layout for the two boards */
+.boards-wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.boards-wrapper .board-legend,
+.boards-wrapper .attack-controls {
+    grid-column: 1 / -1;
+}
+
 .board-section {
     background: linear-gradient(135deg,
         rgba(30, 60, 114, 0.9) 0%,
@@ -624,7 +636,7 @@ main {
 
 .board-header {
     display: grid;
-    grid-template-columns: 100px repeat(6, 1fr);
+    grid-template-columns: 90px repeat(6, 1fr);
     background: linear-gradient(135deg, #0d47a1 0%, #1565c0 100%);
     color: white;
 }
@@ -659,7 +671,7 @@ main {
 
 .board-row {
     display: grid;
-    grid-template-columns: 100px repeat(6, 1fr);
+    grid-template-columns: 90px repeat(6, 1fr);
     border-bottom: 1px solid rgba(66, 165, 245, 0.3);
 }
 
@@ -691,7 +703,7 @@ main {
     cursor: pointer;
     transition: all 0.3s ease;
     position: relative;
-    min-height: 60px;
+    min-height: 54px;
     background: rgba(255, 255, 255, 0.02);
 }
 
@@ -934,8 +946,8 @@ main {
 }
 
 .ship-cell {
-    width: 30px;
-    height: 30px;
+    width: 27px;
+    height: 27px;
     background: linear-gradient(135deg, #1976d2 0%, #2196f3 100%);
     border: 2px solid #0d47a1;
     border-radius: 4px;
@@ -1129,6 +1141,10 @@ body::after {
         grid-template-columns: 1fr;
         gap: 1.5rem;
     }
+
+    .boards-wrapper {
+        grid-template-columns: 1fr;
+    }
     
     .game-info {
         grid-template-columns: 1fr;
@@ -1163,11 +1179,11 @@ body::after {
     }
     
     .board-header {
-        grid-template-columns: 80px repeat(6, 1fr);
+        grid-template-columns: 72px repeat(6, 1fr);
     }
-    
+
     .board-row {
-        grid-template-columns: 80px repeat(6, 1fr);
+        grid-template-columns: 72px repeat(6, 1fr);
     }
     
     .verb-cell, .pronoun-cell {
@@ -1177,7 +1193,7 @@ body::after {
     
     .board-cell {
         padding: 0.8rem;
-        min-height: 50px;
+        min-height: 45px;
     }
     
     .ships-list {
@@ -1204,11 +1220,11 @@ body::after {
 
 @media (max-width: 480px) {
     .board-header {
-        grid-template-columns: 60px repeat(6, 1fr);
+        grid-template-columns: 54px repeat(6, 1fr);
     }
-    
+
     .board-row {
-        grid-template-columns: 60px repeat(6, 1fr);
+        grid-template-columns: 54px repeat(6, 1fr);
     }
     
     .verb-cell, .pronoun-cell {
@@ -1218,7 +1234,7 @@ body::after {
     
     .board-cell {
         padding: 0.5rem;
-        min-height: 40px;
+        min-height: 36px;
     }
     
     .board-cell::before {


### PR DESCRIPTION
## Summary
- shrink board header columns and cells by 10%
- reduce ship size accordingly
- arrange the two boards side by side using new `.boards-wrapper` grid
- make layout responsive so boards stack on narrow screens

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6877695104f08327b1e50ea2c29bb5e6