### PR TITLE
Implement ship placement validation and relocation

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         <div id="game-phase" class="game-phase">
             <span id="phase-text">Phase: Ship Placement</span>
             <div id="ship-placement-controls" class="ship-controls">
-                <button id="fix-ships-btn" class="btn btn-success">Fix Ships</button>
+                <button id="fix-ships-btn" class="btn btn-success btn-disabled" disabled>Fix Ships</button>
                 <div class="ship-counter">
                     <span>Ships to place: <span id="ships-remaining">5</span></span>
                 </div>
@@ -59,6 +59,7 @@
                     <div id="ship-carrier" class="ship selectable-ship" data-ship="carrier" data-size="5" data-orientation="horizontal">
                         <span class="ship-name">Carrier (5)</span>
                         <button class="rotate-btn" onclick="rotateShip(this)">↻</button>
+                        <button class="reset-ship-btn" onclick="resetIndividualShip('carrier')">↺</button>
                         <div class="ship-visual">
                             <div class="ship-cell"></div>
                             <div class="ship-cell"></div>
@@ -70,6 +71,7 @@
                     <div id="ship-battleship" class="ship selectable-ship" data-ship="battleship" data-size="4" data-orientation="horizontal">
                         <span class="ship-name">Battleship (4)</span>
                         <button class="rotate-btn" onclick="rotateShip(this)">↻</button>
+                        <button class="reset-ship-btn" onclick="resetIndividualShip('battleship')">↺</button>
                         <div class="ship-visual">
                             <div class="ship-cell"></div>
                             <div class="ship-cell"></div>
@@ -80,6 +82,7 @@
                     <div id="ship-cruiser" class="ship selectable-ship" data-ship="cruiser" data-size="3" data-orientation="horizontal">
                         <span class="ship-name">Cruiser (3)</span>
                         <button class="rotate-btn" onclick="rotateShip(this)">↻</button>
+                        <button class="reset-ship-btn" onclick="resetIndividualShip('cruiser')">↺</button>
                         <div class="ship-visual">
                             <div class="ship-cell"></div>
                             <div class="ship-cell"></div>
@@ -89,6 +92,7 @@
                     <div id="ship-submarine" class="ship selectable-ship" data-ship="submarine" data-size="3" data-orientation="horizontal">
                         <span class="ship-name">Submarine (3)</span>
                         <button class="rotate-btn" onclick="rotateShip(this)">↻</button>
+                        <button class="reset-ship-btn" onclick="resetIndividualShip('submarine')">↺</button>
                         <div class="ship-visual">
                             <div class="ship-cell"></div>
                             <div class="ship-cell"></div>
@@ -98,6 +102,7 @@
                     <div id="ship-destroyer" class="ship selectable-ship" data-ship="destroyer" data-size="2" data-orientation="horizontal">
                         <span class="ship-name">Destroyer (2)</span>
                         <button class="rotate-btn" onclick="rotateShip(this)">↻</button>
+                        <button class="reset-ship-btn" onclick="resetIndividualShip('destroyer')">↺</button>
                         <div class="ship-visual">
                             <div class="ship-cell"></div>
                             <div class="ship-cell"></div>

--- a/style.css
+++ b/style.css
@@ -318,9 +318,20 @@ header h1 {
 .btn-success:hover {
     background: linear-gradient(135deg, #1b5e20 0%, #2e7d32 100%);
     transform: translateY(-2px);
-    box-shadow: 
+    box-shadow:
         0 6px 20px rgba(27, 94, 32, 0.4),
         inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.btn-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: #666 !important;
+}
+
+.btn-disabled:hover {
+    transform: none !important;
+    box-shadow: none !important;
 }
 
 .btn-state {
@@ -892,9 +903,28 @@ main {
 .ship.active {
     border-color: #81c784;
     background: linear-gradient(135deg, rgba(129, 199, 132, 0.2) 0%, rgba(129, 199, 132, 0.1) 100%);
-    box-shadow: 
+    box-shadow:
         0 0 20px rgba(129, 199, 132, 0.5),
         inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.ship.ship-placed-ui {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: linear-gradient(135deg, rgba(76, 175, 80, 0.3) 0%, rgba(129, 199, 132, 0.3) 100%);
+    border-color: #4caf50;
+}
+
+.ship.ship-placed-ui:hover {
+    transform: none;
+    box-shadow: none;
+}
+
+.ship.ship-placed-ui .ship-name::after {
+    content: " \2713 PLACED";
+    color: #4caf50;
+    font-size: 0.8rem;
+    font-weight: bold;
 }
 
 .ship-name {
@@ -921,6 +951,22 @@ main {
 
 .rotate-btn:hover {
     background: rgba(255, 255, 255, 0.1);
+}
+
+.reset-ship-btn {
+    display: block;
+    margin: 0.3rem auto;
+    background: transparent;
+    border: 1px solid #ef5350;
+    color: #ef5350;
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 0.2rem 0.5rem;
+    transition: background 0.3s ease;
+}
+
+.reset-ship-btn:hover {
+    background: rgba(239, 83, 80, 0.1);
 }
 
 @keyframes slideIn {


### PR DESCRIPTION
## Summary
- prevent selecting ships that are already placed
- visually indicate ships that are placed and disable the fix button until all ships are placed
- allow relocating ships with a reset button on each ship
- disable Fix Ships button at start
- update ship placement logic and reset game handling

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6877821f5f688327b56a11187c6e5ecd