### PR TITLE
Improve game board responsiveness on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -502,8 +502,9 @@ main {
     border: 2px solid #1976d2;
     border-radius: 12px;
     overflow: hidden;
+    overflow-x: auto;
     background: rgba(255, 255, 255, 0.05);
-    box-shadow: 
+    box-shadow:
         0 8px 25px rgba(0, 0, 0, 0.3),
         inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
@@ -1067,11 +1068,11 @@ main {
     }
     
     .board-header {
-        grid-template-columns: 72px repeat(6, 1fr);
+        grid-template-columns: 72px repeat(6, minmax(70px, 1fr));
     }
 
     .board-row {
-        grid-template-columns: 72px repeat(6, 1fr);
+        grid-template-columns: 72px repeat(6, minmax(70px, 1fr));
     }
     
     .verb-cell, .pronoun-cell {
@@ -1108,11 +1109,11 @@ main {
 
 @media (max-width: 480px) {
     .board-header {
-        grid-template-columns: 54px repeat(6, 1fr);
+        grid-template-columns: 54px repeat(6, minmax(60px, 1fr));
     }
 
     .board-row {
-        grid-template-columns: 54px repeat(6, 1fr);
+        grid-template-columns: 54px repeat(6, minmax(60px, 1fr));
     }
     
     .verb-cell, .pronoun-cell {


### PR DESCRIPTION
## Summary
- enable horizontal scrolling inside `.game-board`
- reduce min column width for pronoun/conjugation columns in smaller breakpoints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687866bcf9f8832797c91a4ac207d4c2