### PR TITLE
Add tooltip for Copy List

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,14 @@
             <div class="info-section">
                 <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem;">
                     <h3 id="selected-verbs-heading">Selected Verbs</h3>
-                    <button id="copy-verbs-btn" class="btn btn-secondary" style="font-size: 0.8rem; padding: 0.5rem 0.8rem;">Copy List</button>
+                    <div class="tooltip-container">
+                        <button id="copy-verbs-btn" class="btn btn-secondary" style="font-size: 0.8rem; padding: 0.5rem 0.8rem;">Copy List</button>
+                        <span class="tooltip-trigger" tabindex="0" role="button" aria-describedby="copy-list-tooltip-content">?</span>
+                        <div class="tooltip-content" id="copy-list-tooltip-content">
+                            <p>Copia la lista de verbos en el orden actual. Puedes compartirla con un compañero para que ambos jueguen con los mismos verbos y en el mismo orden. Tu compañero puede pegar la lista al iniciar un "New Custom Game".</p>
+                            <div class="tooltip-arrow"></div>
+                        </div>
+                    </div>
                 </div>
                 <div id="selected-verbs" class="selected-verbs-display">
                     <!-- Selected verbs will be shown here -->

--- a/style.css
+++ b/style.css
@@ -891,6 +891,7 @@ main {
     gap: 0.5rem;
 }
 
+
 .verb-tag {
     background: linear-gradient(135deg, #1976d2 0%, #2196f3 100%);
     color: white;
@@ -901,6 +902,105 @@ main {
     font-family: 'Exo', sans-serif;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* Tooltip Styles */
+.tooltip-container {
+    position: relative;
+    display: inline-block; /* Allows button and trigger to be next to each other */
+    margin-left: 10px; /* Space between button and tooltip trigger */
+}
+
+.tooltip-trigger {
+    font-family: 'Orbitron', monospace;
+    font-weight: 700;
+    font-size: 0.9rem;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #42a5f5 0%, #2196f3 100%);
+    color: white;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus {
+    background: linear-gradient(135deg, #64b5f6 0%, #42a5f5 100%);
+    transform: scale(1.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+    outline: none; /* Remove default focus outline */
+}
+
+.tooltip-content {
+    visibility: hidden;
+    opacity: 0;
+    width: 250px; /* Adjust width as needed */
+    background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+    color: #e3f2fd;
+    text-align: left;
+    border-radius: 8px;
+    padding: 15px;
+    position: absolute;
+    z-index: 10;
+    bottom: 125%; /* Position above the trigger */
+    left: 50%;
+    transform: translateX(-50%) translateY(10px); /* Initial offset for animation */
+    transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(66, 165, 245, 0.3);
+    backdrop-filter: blur(5px);
+    font-size: 0.9rem;
+}
+
+.tooltip-trigger:hover + .tooltip-content,
+.tooltip-trigger:focus + .tooltip-content {
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(-50%) translateY(0); /* Move to final position */
+}
+
+.tooltip-content p {
+    margin-bottom: 10px;
+    line-height: 1.5;
+    font-family: 'Exo', sans-serif;
+}
+
+.tooltip-content .tooltip-arrow {
+    content: '';
+    position: absolute;
+    top: 100%; /* At the bottom of the tooltip content */
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 8px;
+    border-style: solid;
+    border-color: #2a5298 transparent transparent transparent; /* Arrow pointing down */
+    filter: drop-shadow(0 3px 2px rgba(0, 0, 0, 0.2)); /* Shadow for the arrow */
+}
+
+/* Responsive adjustments for tooltip */
+@media (max-width: 768px) {
+    .tooltip-content {
+        width: 200px; /* Smaller width on small screens */
+        padding: 10px;
+        font-size: 0.8rem;
+        bottom: 100%; /* Adjust position slightly */
+        left: 0;
+        transform: translateX(0) translateY(10px); /* Align left, no X translate */
+    }
+    .tooltip-trigger:hover + .tooltip-content,
+    .tooltip-trigger:focus + .tooltip-content {
+        transform: translateX(0) translateY(0);
+    }
+    .tooltip-content .tooltip-arrow {
+        left: 15px; /* Adjust arrow position for left-aligned tooltip */
+        transform: translateX(0);
+    }
 }
 
 /* Attack Modal */


### PR DESCRIPTION
## Summary
- wrap the 'Copy List' button with a tooltip container
- document tooltip info text in index.html
- style tooltip with gradient, shadow and responsive rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878992a235c83278cb0f73553b76b1a